### PR TITLE
Adds `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = tab
+indent_size = 4
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
@rcarraretto I've been adding this to the projects we work on, Anna told me about the preferences on whitespace this helps to setup it as well the tabs if you have the .editorconfig plugin which are available for most of the editor http://editorconfig.org 

It's just a convenience so you don't need to setup each project.