### PR TITLE
Adds `core.user` module

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2,10 +2,8 @@
 
 var createAttribute = require('./attribute');
 var createRecord = require('./record');
-var createUser = require('./user');
 
 module.exports = {
 	attribute: createAttribute,
-	record: createRecord,
-	user: createUser
+	record: createRecord
 };

--- a/src/data.js
+++ b/src/data.js
@@ -5,8 +5,10 @@ var FormDao = require('./form-dao');
 var FieldDao = require('./field-dao');
 var RecordDao = require('./record-dao');
 var RecordDaoRaw = require('./record-dao-raw');
+var createUser = require('./user');
 
 var createDataModule = function(znHttp) {
+
 	var data = {};
 	var api = createApi(znHttp);
 	var formDao = FormDao(api);
@@ -21,6 +23,10 @@ var createDataModule = function(znHttp) {
 
 	data.forRecordsOf = function(formId) {
 		return RecordDao(formDao, RecordDaoRaw(api, formId), formId);
+	};
+
+	data.user = function() {
+		return createUser(api);
 	};
 
 	return data;

--- a/src/user.js
+++ b/src/user.js
@@ -3,7 +3,7 @@
 var Promise = require('bluebird');
 var get = require('lodash.get');
 
-var User = function(http) {
+var User = function(api) {
 
 	var user = {};
 
@@ -26,7 +26,7 @@ var User = function(http) {
 	user.getId = function() {
 
 		var getUser = function() {
-			return http.get('/users/me?attributes=id&related=null');
+			return api.get('/users/me?attributes=id&related=null');
 		};
 
 		var onError = function(response) {
@@ -52,7 +52,7 @@ var User = function(http) {
 
 		var onSuccess = function(response) {
 
-			var userId = get(response.getBody(), 'data.id') || false;
+			var userId = get(response, 'id') || false;
 
 			return userId;
 
@@ -70,23 +70,17 @@ var User = function(http) {
 
 		var getMembershipCount = function(userId) {
 
-			var endpoint = ['/workspaces', workspaceId, 'members', 'count'].join('/');
+			var endpoint = ['/workspaces', workspaceId, 'members'].join('/');
 
 			var options = {
-				params: {
-					'user.id': userId
-				}
+				'user.id': userId
 			};
 
-			return http.get(endpoint, options);
+			return api.count(endpoint, options);
 
 		};
 
-		var checkMembership = function(response) {
-
-			var body = response.getBody();
-
-			var count = get(body, 'totalCount');
+		var checkMembership = function(count) {
 
 			return count === 1 ? true : false;
 

--- a/test/user-spec.js
+++ b/test/user-spec.js
@@ -8,7 +8,7 @@ describe('User', function() {
 
 	var nock = require('nock');
 
-	var user = zengo.core.user(http);
+	var user = zengo.data(http).user();
 
 	var apiError = {
 		name: 'ApiError',


### PR DESCRIPTION
This is a port/adaptation from source code we use on `program-manager` and we going to use on `email-tracker` too.

This module can be used to get the current user id `core.user(http).getId()` based on the `headers.authorization`

or check if the user is a member of the current workspace `core.user(http).isAuthorizedInWorkspace(workspaceId)`

I was not sure if it's the best place for this api I was think before to implement `zengo.auth(http).getUserId()` and `zengo.auth(http).isAuthorizedInWorkspace(workspaceId)`

