### PR TITLE
Renames `data.user` to `data.forUsers`

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -25,7 +25,7 @@ var createDataModule = function(znHttp) {
 		return RecordDao(formDao, RecordDaoRaw(api, formId), formId);
 	};
 
-	data.user = function() {
+	data.forUsers = function() {
 		return createUser(api);
 	};
 


### PR DESCRIPTION
I forgot about this, but following the other apis seems `forUsers` is better then `user` or `auth`