### PR TITLE
Added method isAdmin to the User API

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -69,7 +69,7 @@ var User = function(api) {
 
 		var getMemberInfo = function(userId) {
 
-			var endpoint = ['/workspaces', workspaceId,'members'].join('/');
+			var endpoint = ['/workspaces', workspaceId, 'members'].join('/');
 
 			var options = {
 				'user.id': userId


### PR DESCRIPTION
It was needed for my task and I decided to implement it in zengo rather than on my backend service.

Question:

1. Should I assume that I can rely on the role ID (1,2) for Owner and Administrator.  
2. Or should I call to the /roles API?